### PR TITLE
Modified Limit Switch Constructor

### DIFF
--- a/src/HematologistAnalogLimitSwitch.cpp
+++ b/src/HematologistAnalogLimitSwitch.cpp
@@ -1,8 +1,8 @@
 #include "HematologistAnalogLimitSwitch.h"
 
-HematologistAnalogLimitSwitch::HematologistAnalogLimitSwitch()
+HematologistAnalogLimitSwitch::HematologistAnalogLimitSwitch(int limitSwitchChannel)
 {
-	ai = new AnalogInput(LIMIT_SWITCH_CHANNEL);
+	ai = new AnalogInput(limitSwitchChannel);
 
 }
 

--- a/src/HematologistAnalogLimitSwitch.h
+++ b/src/HematologistAnalogLimitSwitch.h
@@ -6,7 +6,7 @@
 class HematologistAnalogLimitSwitch
 {
 public:
-	HematologistAnalogLimitSwitch();
+	HematologistAnalogLimitSwitch(int limitSwitchChannel);
 	~HematologistAnalogLimitSwitch();
 
 	bool limitSwitchIsPressed();


### PR DESCRIPTION
The channel that we assign to the limit switch is now a parameter of the
constructor so that channels can be passed in on object creation
