### PR TITLE
Adding relays

### DIFF
--- a/src/HematologistMacros.h
+++ b/src/HematologistMacros.h
@@ -70,6 +70,10 @@ Manip Joystick:
 #define SECOND_TIER_PISTON_CHANNEL_A		(7)
 #define SECOND_TIER_PISTON_CHANNEL_B 		(6)
 
+//Relays
+#define LONG_ARM_RELAY_CHANNEL_1			(1)	//TODO: get correct number
+#define LONG_ARM_RELAY_CHANNEL_2			(2)	//TODO: get correct number
+
 //Encoders
 #define BACK_RIGHT_ENCODER_CHANNEL_A  (0)   
 #define BACK_RIGHT_ENCODER_CHANNEL_B  (1)   

--- a/src/HematologistMacros.h
+++ b/src/HematologistMacros.h
@@ -71,8 +71,8 @@ Manip Joystick:
 #define SECOND_TIER_PISTON_CHANNEL_B 		(6)
 
 //Relays
-#define LONG_ARM_RELAY_CHANNEL_1			(1)	//TODO: get correct number
-#define LONG_ARM_RELAY_CHANNEL_2			(2)	//TODO: get correct number
+#define LONG_ARM_RELAY_OPEN_CHANNEL			(1)	//TODO: get correct number
+#define LONG_ARM_RELAY_CLOSE_CHANNEL			(2)	//TODO: get correct number
 
 //Encoders
 #define BACK_RIGHT_ENCODER_CHANNEL_A  (0)   

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -17,7 +17,7 @@ HematologistManipulator::HematologistManipulator(Joystick* manipJoystick)
 	liftEncoder = new Encoder(LIFT_ENCODER_CHANNEL_A, LIFT_ENCODER_CHANNEL_B);
 	compressor = new Compressor(0);
 
-	toggleCompressor(true, false);
+	compressor->SetClosedLoopControl(true);
 
 	this->manipJoystick = manipJoystick;
 
@@ -115,14 +115,6 @@ void HematologistManipulator::moveLift(float speed)
 			}
 		}
 	}
-}
-
-void HematologistManipulator::toggleCompressor(bool start, bool stop)
-{
-	if (start)
-		compressor->SetClosedLoopControl(start);
-	if (stop)
-		compressor->SetClosedLoopControl(stop);
 }
 
 HematologistAnalogLimitSwitch* HematologistManipulator::getLimitSwitch(bool top)

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -32,6 +32,8 @@ HematologistManipulator::HematologistManipulator(Joystick* manipJoystick)
 	forkliftOpen = true;
 	secondTierOpen = true;
 
+	flapsIsOpen = false;
+
 	automaticActivation = false;
 
 	longArmOpen1 = longArmOpen2 = longArmOpen3 = false;
@@ -400,4 +402,9 @@ Relay* HematologistManipulator::getRelay(int whichOne)
 		case 2: return longArmFlap2;
 		default: return longArmFlap1;
 	}
+}
+
+bool HematologistManipulator::flapsIsOpen()
+{
+	return flapsIsOpen;
 }

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -8,8 +8,8 @@ HematologistManipulator::HematologistManipulator(Joystick* manipJoystick)
 	forkliftPiston = new DoubleSolenoid(FORKLIFT_PISTON_CHANNEL_A, FORKLIFT_PISTON_CHANNEL_B);
 	longArmPiston = new DoubleSolenoid(LONG_ARM_PISTON_CHANNEL_A, LONG_ARM_PISTON_CHANNEL_B);
 
-	longArmFlap1 = new Relay(LONG_ARM_RELAY_CHANNEL_1);
-	longArmFlap2 = new Relay(LONG_ARM_RELAY_CHANNEL_2);
+	longArmFlapOpen = new Relay(LONG_ARM_RELAY_OPEN_CHANNEL);
+	longArmFlapClose = new Relay(LONG_ARM_RELAY_CLOSE_CHANNEL);
 
 	openPiston(true, true);
 	openPiston(false, true);
@@ -407,4 +407,13 @@ Relay* HematologistManipulator::getRelay(int whichOne)
 bool HematologistManipulator::flapsIsOpen()
 {
 	return flapsIsOpen;
+}
+
+void HematologistManipulator::openFlaps(bool open)
+{
+	if (open)
+	{
+
+	}else
+		return;
 }

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -8,8 +8,8 @@ HematologistManipulator::HematologistManipulator(Joystick* manipJoystick)
 	forkliftPiston = new DoubleSolenoid(FORKLIFT_PISTON_CHANNEL_A, FORKLIFT_PISTON_CHANNEL_B);
 	longArmPiston = new DoubleSolenoid(LONG_ARM_PISTON_CHANNEL_A, LONG_ARM_PISTON_CHANNEL_B);
 
-	longArmRelay1 = new Relay(LONG_ARM_RELAY_CHANNEL_1);
-	longArmRelay2 = new Relay(LONG_ARM_RELAY_CHANNEL_2);
+	longArmFlap1 = new Relay(LONG_ARM_RELAY_CHANNEL_1);
+	longArmFlap2 = new Relay(LONG_ARM_RELAY_CHANNEL_2);
 
 	openPiston(true, true);
 	openPiston(false, true);
@@ -396,8 +396,8 @@ Relay* HematologistManipulator::getRelay(int whichOne)
 {
 	switch(whichOne)
 	{
-		case 1: return longArmRelay1;
-		case 2: return longArmRelay2;
-		default: return longArmRelay1;
+		case 1: return longArmFlap1;
+		case 2: return longArmFlap2;
+		default: return longArmFlap1;
 	}
 }

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -394,14 +394,12 @@ void HematologistManipulator::automaticallyOpenTier()
 		automaticActivation = false;
 }
 
-Relay* HematologistManipulator::getRelay(int whichOne)
+Relay* HematologistManipulator::getLongArmFlap(bool open)
 {
-	switch(whichOne)
-	{
-		case 1: return longArmFlap1;
-		case 2: return longArmFlap2;
-		default: return longArmFlap1;
-	}
+	if (open)
+		return longArmFlapOpen;
+	else
+		return longArmFlapClose;
 }
 
 bool HematologistManipulator::flapsIsOpen()

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -166,40 +166,6 @@ Encoder* HematologistManipulator::getLiftEncoder()
   return liftEncoder;
 }
 
-void HematologistManipulator::activateForklift(bool change)
-{
-	if (change)
-	{
-		if (forkliftPiston->Get() == DoubleSolenoid::kReverse)
-		{
-			forkliftPiston->Set(DoubleSolenoid::kForward);
-			forkliftOpen = false;
-		}
-		else
-		{
-			forkliftPiston->Set(DoubleSolenoid::kForward);
-			forkliftOpen = true;
-		}
-	}
-}
-
-void HematologistManipulator::activateSecondTier(bool change)
-{
-	if (change)
-	{
-		if (secondTierPiston->Get() == DoubleSolenoid::kReverse)
-		{
-			secondTierPiston->Set(DoubleSolenoid::kForward);
-			secondTierOpen = false;
-		}
-		else
-		{
-			secondTierPiston->Set(DoubleSolenoid::kReverse);
-			secondTierOpen = true;
-		}
-	}
-}
-
 bool HematologistManipulator::getSecondTierState()
 {
 	return secondTierOpen;

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -413,7 +413,9 @@ void HematologistManipulator::openFlaps(bool open)
 {
 	if (open)
 	{
-
+		longArmFlapOpen->Set(Relay::kOn);
+		longArmFlapClose->Set(Relay::kOff);
+		flapsIsOpen = true;
 	}else
 		return;
 }

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -8,6 +8,9 @@ HematologistManipulator::HematologistManipulator(Joystick* manipJoystick)
 	forkliftPiston = new DoubleSolenoid(FORKLIFT_PISTON_CHANNEL_A, FORKLIFT_PISTON_CHANNEL_B);
 	longArmPiston = new DoubleSolenoid(LONG_ARM_PISTON_CHANNEL_A, LONG_ARM_PISTON_CHANNEL_B);
 
+	longArmRelay1 = new Relay(LONG_ARM_RELAY_CHANNEL_1);
+	longArmRelay2 = new Relay(LONG_ARM_RELAY_CHANNEL_2);
+
 	openPiston(true, true);
 	openPiston(false, true);
 

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -392,7 +392,7 @@ void HematologistManipulator::automaticallyOpenTier()
 		automaticActivation = false;
 }
 
-Relay* getRelay(int whichOne)
+Relay* HematologistManipulator::getRelay(int whichOne)
 {
 	switch(whichOne)
 	{

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -391,3 +391,13 @@ void HematologistManipulator::automaticallyOpenTier()
 	if (liftEncoder->Get() > 1800 + LIFT_DEADZONE)
 		automaticActivation = false;
 }
+
+Relay* getRelay(int whichOne)
+{
+	switch(whichOne)
+	{
+		case 1: return longArmRelay1;
+		case 2: return longArmRelay2;
+		default: return longArmRelay1;
+	}
+}

--- a/src/HematologistManipulator.cpp
+++ b/src/HematologistManipulator.cpp
@@ -419,3 +419,14 @@ void HematologistManipulator::openFlaps(bool open)
 	}else
 		return;
 }
+
+void HematologistManipulator::closeFlaps(bool close)
+{
+	if (close)
+	{
+		longArmFlapOpen->Set(Relay::kOff);
+		longArmFlapClose->Set(Relay::kOn);
+		flapsIsOpen = false;
+	}else
+		return;
+}

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -49,11 +49,12 @@ public:
 	HematologistManipulator(Joystick* manipJoystick);
 	~HematologistManipulator();
 
+	//Open or Closed?
 	bool getSecondTierState();
 	bool getForkliftState();
 
+
 	void resetEncoders();
-	void toggleCompressor(bool start, bool stop);
 
 	void moveLift(float speed);
 

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -31,7 +31,7 @@ private:
 	bool secondTierOpen;
 	bool forkliftOpen;
 	bool binHuggerOpen;
-	bool 
+	bool flapsOpen;
 
 	bool longArmOpen1;
 	bool longArmOpen2;

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -63,7 +63,7 @@ public:
 	bool binHuggerIsOpen();
   	bool forkliftIsOpen();
   	bool secondTierIsOpen();
-  	Relay* getLongArmFlap(int whichOne)
+  	Relay* getLongArmFlap(int whichOne);
   	bool flapsIsOpen();
 
 	//Functionality of Manip

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -63,7 +63,7 @@ public:
 	bool binHuggerIsOpen();
   	bool forkliftIsOpen();
   	bool secondTierIsOpen();
-  	Relay* getLongArmFlap(int whichOne);
+  	Relay* getLongArmFlap(bool open);
   	bool flapsIsOpen();
 
 	//Functionality of Manip

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -12,8 +12,8 @@ private:
 	DoubleSolenoid* forkliftPiston;
 	DoubleSolenoid* longArmPiston;
 
-	Relay* longArmRelay1;
-	Relay* longArmRelay2;
+	Relay* longArmFlap1;
+	Relay* longArmFlap2;
 
 	Joystick* manipJoystick;
 
@@ -31,6 +31,7 @@ private:
 	bool secondTierOpen;
 	bool forkliftOpen;
 	bool binHuggerOpen;
+	bool 
 
 	bool longArmOpen1;
 	bool longArmOpen2;
@@ -62,7 +63,7 @@ public:
 	bool binHuggerIsOpen();
   	bool forkliftIsOpen();
   	bool secondTierIsOpen();
-  	Relay* getRelay(int whichOne);
+  	Relay* getLongArmFlap(int whichOne)
 
 	//Functionality of Manip
 	void resetEncoders();
@@ -95,6 +96,8 @@ public:
 	void longArmMoveIn();
 
 	void automaticallyOpenTier();
+
+
 };
 
 #endif

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -49,30 +49,26 @@ public:
 	HematologistManipulator(Joystick* manipJoystick);
 	~HematologistManipulator();
 
-	//Open or Closed?
+	//Get Functions
 	bool getSecondTierState();
 	bool getForkliftState();
-
-
-	void resetEncoders();
-
-	void moveLift(float speed);
-
 	HematologistAnalogLimitSwitch* getLimitSwitch(bool top);
-
-	void activateCompressor(bool start);
-
-	void controlCompressor(bool change);
-
 	bool getCompressorOn();
-
 	Talon* getManipTalon(bool right);
 	Encoder* getLiftEncoder();
+	DoubleSolenoid* getForkliftPiston();
+	DoubleSolenoid* getSecondTierPiston();
+	bool compressorIsOn();
+	bool binHuggerIsOpen();
+  	bool forkliftIsOpen();
+  	bool secondTierIsOpen();
 
+	//Functionality of Manip
+	void resetEncoders();
+	void moveLift(float speed);
+	void activateCompressor(bool start);
+	void controlCompressor(bool change);
   	void automaticallyActivate(bool activate);
-
-  	DoubleSolenoid* getForkliftPiston();
-  	DoubleSolenoid* getSecondTierPiston();
 
   	void openPiston(bool forklift, bool open);
   	void closePiston(bool forklift, bool close);
@@ -80,14 +76,8 @@ public:
   	void turnOnCompressor(bool start);
   	void turnOffCompressor(bool stop);
 
-  	bool compressorIsOn();
-
   	void openBinHugger(bool open);
   	void closeBinHugger(bool close);
-
-  	bool binHuggerIsOpen();
-  	bool forkliftIsOpen();
-  	bool secondTierIsOpen();
 
   	void longArmOpenStep1(bool step1);
   	void longArmOpenStep2(bool step2);

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -12,6 +12,9 @@ private:
 	DoubleSolenoid* forkliftPiston;
 	DoubleSolenoid* longArmPiston;
 
+	Relay* longArmRelay1;
+	Relay* longArmRelay2;
+
 	Joystick* manipJoystick;
 
 	Encoder* liftEncoder;

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -12,8 +12,8 @@ private:
 	DoubleSolenoid* forkliftPiston;
 	DoubleSolenoid* longArmPiston;
 
-	Relay* longArmFlap1;
-	Relay* longArmFlap2;
+	Relay* longArmFlapOpen;
+	Relay* longArmFlapClose;
 
 	Joystick* manipJoystick;
 
@@ -97,6 +97,9 @@ public:
 	void longArmMoveIn();
 
 	void automaticallyOpenTier();
+
+	void openFlaps(bool open);
+	void closeFlaps(bool close);
 
 
 };

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -49,9 +49,6 @@ public:
 	HematologistManipulator(Joystick* manipJoystick);
 	~HematologistManipulator();
 
-	void activateForklift(bool open);
-	void activateSecondTier(bool open);
-
 	bool getSecondTierState();
 	bool getForkliftState();
 

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -62,6 +62,7 @@ public:
 	bool binHuggerIsOpen();
   	bool forkliftIsOpen();
   	bool secondTierIsOpen();
+  	Relay* getRelay(int whichOne);
 
 	//Functionality of Manip
 	void resetEncoders();

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -44,12 +44,10 @@ private:
 	bool disableEncoders;
 
 public:
+
+	//Constructor
 	HematologistManipulator(Joystick* manipJoystick);
 	~HematologistManipulator();
-
-	void openBinHugger();
-	void openForklift();
-	void openSecondTier();
 
 	void activateForklift(bool open);
 	void activateSecondTier(bool open);

--- a/src/HematologistManipulator.h
+++ b/src/HematologistManipulator.h
@@ -64,6 +64,7 @@ public:
   	bool forkliftIsOpen();
   	bool secondTierIsOpen();
   	Relay* getLongArmFlap(int whichOne)
+  	bool flapsIsOpen();
 
 	//Functionality of Manip
 	void resetEncoders();


### PR DESCRIPTION
Adds relays in manipulator files to open the flaps of the longArm. This may be switched where the solenoid opens the flaps and the relays the longArm but as the solenoid is currently coded to open the longArm, I'm hoping chris didn't do something where he switches it up. 

Several functions that were of no use were deleted while other functions (such as appropriate getFunctions/open/close functions were made). Appropriate Macros were created for the channels for the Relays. Some moving around of function was done for ease of readability.
